### PR TITLE
Add solver conflict cactus plots to benchmark reports

### DIFF
--- a/paper-graphics/README.md
+++ b/paper-graphics/README.md
@@ -70,6 +70,9 @@ python3 comparison_figure_generator.py results.json --strategy1 concrete --strat
 ### Output Files
 
 - `runtime_scatter.tikz` - Runtime comparison scatter plot
+- `runtime_cactus_plot.tex` - Runtime cactus plot across all strategies
+- `instantiation_cactus_plot.tex` - Axiom instantiation cactus plot
+- `conflict_cactus_plot.tex` - Total solver conflicts cactus plot
 - `results_table.tikz` - LaTeX table of results
 
 **LaTeX Requirements:** `pgfplots`, `longtable`, `booktabs`

--- a/paper-graphics/main.py
+++ b/paper-graphics/main.py
@@ -9,11 +9,13 @@ from src.data_generators import (
     CactusPlotGenerator,
     InstantiationScatterPlotGenerator,
     InstCactusPlotGenerator,
+    ConflictCactusPlotGenerator,
 )
 from src.tikz_generators import (
     ScatterPlotTikzGenerator,
     CactusPlotTikzGenerator,
     InstCactusPlotTikzGenerator,
+    ConflictCactusPlotTikzGenerator,
     TableTikzGenerator,
 )
 
@@ -228,6 +230,28 @@ def generate_figures(grouped, strategy_keys, all_results, output_dir):
         )
 
         output_file = output_dir / "instantiation_cactus_plot.tex"
+        output_file.write_text(tikz_code)
+        print(f"  Saved: {output_file}")
+
+    # Generate solver conflict cactus plot
+    print(f"\n{'=' * 60}")
+    print("Generating solver conflict cactus plot")
+    print(f"{'=' * 60}")
+
+    conflict_cactus_gen = ConflictCactusPlotGenerator(all_results)
+    conflict_cactus_data = conflict_cactus_gen.generate_data()
+
+    if conflict_cactus_data:
+        tikz_code = ConflictCactusPlotTikzGenerator.generate(
+            conflict_cactus_data,
+            title="Solver Conflict Count Comparison",
+            xlabel="Number of Benchmarks",
+            ylabel="Total Solver Conflicts",
+            caption="Cactus plot comparing the total solver conflicts needed across all strategies (lower lines are better).",
+            use_log_scale=True,
+        )
+
+        output_file = output_dir / "conflict_cactus_plot.tex"
         output_file.write_text(tikz_code)
         print(f"  Saved: {output_file}")
 

--- a/paper-graphics/report/build_report.py
+++ b/paper-graphics/report/build_report.py
@@ -26,6 +26,7 @@ FIGURE_PREFIXES = (
     "instantiation_scatter_",
     "runtime_cactus_plot",
     "instantiation_cactus_plot",
+    "conflict_cactus_plot",
 )
 GENERATED_TEX_PATTERNS = (
     "all_benchmarks_table.tex",
@@ -33,9 +34,14 @@ GENERATED_TEX_PATTERNS = (
     "shared_benchmark_analysis.tex",
     "runtime_*.tex",
     "instantiation_*.tex",
+    "conflict_*.tex",
     "unique_solves_*.tex",
 )
-GENERATED_ASSET_PATTERNS = ("runtime_*.pdf", "instantiation_*.pdf")
+GENERATED_ASSET_PATTERNS = (
+    "runtime_*.pdf",
+    "instantiation_*.pdf",
+    "conflict_*.pdf",
+)
 
 
 def load_json(path: Path) -> dict:

--- a/paper-graphics/src/analysis.py
+++ b/paper-graphics/src/analysis.py
@@ -69,6 +69,7 @@ def _benchmark_row(result: BenchmarkResult, strategy_id: str) -> dict[str, Any]:
         "solver_time_s": _round(result.solver_time_s),
         "used_instantiations": (result.used_instantiations if result.success else None),
         "num_checks": result.num_checks if result.success else None,
+        "total_conflicts": result.total_conflicts if result.success else None,
     }
 
 
@@ -538,6 +539,7 @@ def write_analysis_exports(
             "solver_time_s",
             "used_instantiations",
             "num_checks",
+            "total_conflicts",
         ],
     )
     _write_csv(

--- a/paper-graphics/src/benchmark_parsing.py
+++ b/paper-graphics/src/benchmark_parsing.py
@@ -22,6 +22,7 @@ class BenchmarkResult:
     used_instantiations: int
     num_checks: int
     solver_time_s: float = 0.0  # Time spent in Z3 solver (seconds)
+    total_conflicts: Optional[float] = None
 
     def get_strategy_id(self) -> str:
         if self.strategy == "abstract" and self.cost_function:
@@ -120,6 +121,18 @@ def extract_solver_time(full_entry: dict, success: bool) -> float:
         return 0.0
 
 
+def extract_total_conflicts(full_entry: dict, success: bool) -> Optional[float]:
+    """Extract the solver's cumulative conflict count for a solved benchmark."""
+    if not success:
+        return None
+    try:
+        entry = successful_payload(full_entry, success)
+        conflicts = entry["solver_statistics"]["stats"].get("conflicts")
+        return float(conflicts) if conflicts is not None else None
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
 class BenchmarkParser:
     """Parser for benchmark JSON results"""
 
@@ -164,6 +177,7 @@ class BenchmarkParser:
             result_entry, strategy, success
         )
         solver_time = extract_solver_time(result_entry, success)
+        total_conflicts = extract_total_conflicts(result_entry, success)
 
         return BenchmarkResult(
             example_name=example_name,
@@ -176,4 +190,5 @@ class BenchmarkParser:
             used_instantiations=used_instantiations,
             num_checks=find_num_checks(result_entry, strategy, success),
             solver_time_s=solver_time,
+            total_conflicts=total_conflicts,
         )

--- a/paper-graphics/src/data_generators.py
+++ b/paper-graphics/src/data_generators.py
@@ -252,3 +252,37 @@ class InstCactusPlotGenerator:
             )
 
         return strategy_instantiations
+
+
+class ConflictCactusPlotGenerator:
+    """Generates solver-conflict cactus plots for strategy comparison."""
+
+    def __init__(self, all_results: List[BenchmarkResult]):
+        self.all_results = all_results
+
+    def generate_data(self) -> Dict[str, List[Optional[float]]]:
+        """Return sorted cumulative solver conflict counts by strategy.
+
+        Failed benchmarks and successful results from older artifacts that do not
+        contain the ``conflicts`` solver statistic are represented as ``None``.
+        """
+        strategy_conflicts = {}
+
+        for result in self.all_results:
+            display_name = result.get_display_name()
+            conflict_count = result.total_conflicts if result.success else None
+            strategy_conflicts.setdefault(display_name, []).append(conflict_count)
+
+        for display_name in strategy_conflicts:
+            strategy_conflicts[display_name].sort(
+                key=lambda value: (
+                    value is None,
+                    value if value is not None else 0,
+                )
+            )
+
+        return {
+            display_name: conflicts
+            for display_name, conflicts in strategy_conflicts.items()
+            if any(conflict is not None for conflict in conflicts)
+        }

--- a/paper-graphics/src/tikz_generators.py
+++ b/paper-graphics/src/tikz_generators.py
@@ -218,6 +218,7 @@ class InstCactusPlotTikzGenerator:
         ylabel: str = "Instantiations",
         caption: str = None,
         use_log_scale: bool = True,
+        label: str = "fig:cactus_inst",
     ) -> str:
         """Generate an instantiation cactus plot comparing strategies
 
@@ -229,6 +230,7 @@ class InstCactusPlotTikzGenerator:
             ylabel: Y-axis label (instantiations)
             caption: Optional figure caption
             use_log_scale: If True, use log scale for y-axis
+            label: LaTeX figure label
 
         Returns:
             TikZ/LaTeX code string
@@ -250,12 +252,12 @@ class InstCactusPlotTikzGenerator:
         # Determine axis type and bounds
         if use_log_scale:
             y_axis = "semilogyaxis"
-            # Pin failed runs to 2x the max successful instantiation count
-            y_max = max_inst * 2
+            y_max = max(max_inst * 2, 2)
+            y_min = 0.5
         else:
             y_axis = "axis"
-            y_max = max_inst * 1.2
-        y_min = 0.01
+            y_max = max(max_inst * 1.2, 1)
+            y_min = 0
         x_max = max_instances * 1.05
 
         # Color mapping for strategies
@@ -278,7 +280,7 @@ class InstCactusPlotTikzGenerator:
     xlabel={{{xlabel}}},
     ylabel={{{ylabel}}},
     xmin=0, xmax={x_max:.0f},
-    ymin={y_min:.0f}, ymax={y_max:.0f},
+    ymin={y_min:.3f}, ymax={y_max:.3f},
     grid=major,
     width=\\columnwidth,
     height=8cm,
@@ -308,9 +310,32 @@ class InstCactusPlotTikzGenerator:
         if caption:
             tikz_code += f"\n\\caption{{{caption}}}"
 
-        tikz_code += "\n\\label{fig:cactus_inst}\n\\end{figure}"
+        tikz_code += f"\n\\label{{{label}}}\n\\end{{figure}}"
 
         return tikz_code
+
+
+class ConflictCactusPlotTikzGenerator:
+    """Generates TikZ cactus plots for cumulative solver conflict counts."""
+
+    @staticmethod
+    def generate(
+        strategy_data: Dict[str, List[Optional[float]]],
+        title: str = "Solver Conflict Cactus Plot",
+        xlabel: str = "Number of Solved Instances",
+        ylabel: str = "Total Solver Conflicts",
+        caption: str = None,
+        use_log_scale: bool = True,
+    ) -> str:
+        return InstCactusPlotTikzGenerator.generate(
+            strategy_data,
+            title=title,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            caption=caption,
+            use_log_scale=use_log_scale,
+            label="fig:cactus_conflicts",
+        )
 
 
 class TableTikzGenerator:
@@ -746,7 +771,9 @@ Strategy & Solved & Timeouts & Avg. Inst. & Unique Solves & \\% w/ Reduction & I
 
         # Create display names
         display_name = strategy_key.replace("_", " ").replace("-", " ").title()
-        baseline_display_name = baseline_strategy.replace("_", " ").replace("-", " ").title()
+        baseline_display_name = (
+            baseline_strategy.replace("_", " ").replace("-", " ").title()
+        )
         for strategies in grouped_results.values():
             if strategy_key in strategies:
                 display_name = strategies[strategy_key].get_display_name()

--- a/paper-graphics/tests/test_analysis.py
+++ b/paper-graphics/tests/test_analysis.py
@@ -28,6 +28,7 @@ def result(
         used_instantiations=10 if success else 10_000_000,
         num_checks=5 if success else 10_000_000,
         solver_time_s=runtime_ms / 2000.0 if success else 0.0,
+        total_conflicts=20 if success else None,
     )
 
 
@@ -113,6 +114,7 @@ class AnalysisTests(unittest.TestCase):
             with benchmark_csv.open(newline="") as input_file:
                 rows = list(csv.DictReader(input_file))
             self.assertEqual(len(rows), 10)
+            self.assertEqual(rows[0]["total_conflicts"], "20")
 
 
 if __name__ == "__main__":

--- a/paper-graphics/tests/test_benchmark_parsing.py
+++ b/paper-graphics/tests/test_benchmark_parsing.py
@@ -27,6 +27,7 @@ class BenchmarkParserTests(unittest.TestCase):
                                         "stats": {
                                             "num checks": 3,
                                             "solver_time": 0.1,
+                                            "conflicts": 11,
                                         }
                                     },
                                 }
@@ -45,6 +46,7 @@ class BenchmarkParserTests(unittest.TestCase):
         self.assertEqual(parsed.result_type, "_FoundProof")
         self.assertEqual(parsed.used_instantiations, 7)
         self.assertEqual(parsed.num_checks, 3)
+        self.assertEqual(parsed.total_conflicts, 11)
 
 
 if __name__ == "__main__":

--- a/paper-graphics/tests/test_conflict_cactus.py
+++ b/paper-graphics/tests/test_conflict_cactus.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from main import generate_figures
+from src.benchmark_parsing import BenchmarkResult
+from src.data_generators import ConflictCactusPlotGenerator
+from src.tikz_generators import ConflictCactusPlotTikzGenerator
+
+
+def result(
+    benchmark: str,
+    conflicts: float | None,
+    *,
+    success: bool = True,
+) -> BenchmarkResult:
+    return BenchmarkResult(
+        example_name=benchmark,
+        strategy="concrete",
+        cost_function=None,
+        runtime_ms=100,
+        depth=5,
+        result_type="Success" if success else "Timeout",
+        success=success,
+        used_instantiations=0,
+        num_checks=1,
+        total_conflicts=conflicts,
+    )
+
+
+class ConflictCactusTests(unittest.TestCase):
+    def test_conflicts_are_sorted_and_missing_values_are_last(self) -> None:
+        data = ConflictCactusPlotGenerator(
+            [
+                result("b.vmt", 8),
+                result("a.vmt", 0),
+                result("c.vmt", None),
+                result("d.vmt", 100, success=False),
+            ]
+        ).generate_data()
+
+        self.assertEqual(data["Z3 Array Theory"], [0, 8, None, None])
+
+    def test_tikz_uses_conflict_label_and_handles_zero_conflicts(self) -> None:
+        tikz = ConflictCactusPlotTikzGenerator.generate(
+            {"Z3 Array Theory": [0, 8, None]}
+        )
+
+        self.assertIn(r"\label{fig:cactus_conflicts}", tikz)
+        self.assertIn("Total Solver Conflicts", tikz)
+        self.assertIn("(1, 1)", tikz)
+        self.assertNotIn("(3,", tikz)
+
+    def test_strategies_without_conflict_statistics_are_omitted(self) -> None:
+        data = ConflictCactusPlotGenerator(
+            [result("a.vmt", None), result("b.vmt", None, success=False)]
+        ).generate_data()
+
+        self.assertEqual(data, {})
+
+    def test_figure_pipeline_writes_conflict_cactus_plot(self) -> None:
+        benchmark = result("examples/array/a.vmt", 8)
+        grouped = {benchmark.example_name: {"concrete": benchmark}}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with redirect_stdout(io.StringIO()):
+                generate_figures(
+                    grouped,
+                    {"concrete"},
+                    [benchmark],
+                    Path(temp_dir),
+                )
+            conflict_plot = Path(temp_dir) / "conflict_cactus_plot.tex"
+
+            self.assertTrue(conflict_plot.exists())
+            self.assertIn(
+                r"\label{fig:cactus_conflicts}",
+                conflict_plot.read_text(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Parse and export cumulative solver conflict statistics.
- Generate conflict cactus plot data and TikZ output.
- Include conflict plots and PDFs in report generation.
- Add configurable labels and improve zero-value instantiation plot bounds.
- Add parsing, analysis, plotting, and pipeline tests.

## Testing

- Added unit tests covering conflict extraction, sorting, missing statistics, TikZ output, and report generation.